### PR TITLE
Implementación de dark mode con persistencia

### DIFF
--- a/src/common/components/ColorModeProvider.tsx
+++ b/src/common/components/ColorModeProvider.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import React, { createContext, useCallback, useEffect, useMemo, useState } from 'react'
+import { PaletteMode, ThemeProvider } from '@mui/material'
+import { createCustomTheme } from '@/config/theme'
+
+interface ColorModeContextProps {
+  mode: PaletteMode
+  toggleColorMode: () => void
+}
+
+export const ColorModeContext = createContext<ColorModeContextProps>({
+  mode: 'light',
+  toggleColorMode: () => {}
+})
+
+export default function ColorModeProvider({ children }: { children: React.ReactNode }) {
+  const [mode, setMode] = useState<PaletteMode>('light')
+
+  useEffect(() => {
+    const stored = localStorage.getItem('colorMode') as PaletteMode | null
+    if (stored) {
+      setMode(stored)
+    }
+  }, [])
+
+  const toggleColorMode = useCallback(() => {
+    setMode(prev => {
+      const newMode = prev === 'light' ? 'dark' : 'light'
+      localStorage.setItem('colorMode', newMode)
+      return newMode
+    })
+  }, [])
+
+  const theme = useMemo(() => createCustomTheme(mode), [mode])
+
+  return (
+    <ColorModeContext.Provider value={{ mode, toggleColorMode }}>
+      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+    </ColorModeContext.Provider>
+  )
+}

--- a/src/common/components/SmartFileInput.tsx
+++ b/src/common/components/SmartFileInput.tsx
@@ -149,7 +149,7 @@ const SmartFileInput = forwardRef<SmartFileInputRef, SmartFileInputProps>(({
       px: 2,
       py: 1.5,
       borderRadius: 2,
-      bgcolor: disabled ? 'action.disabledBackground' : '#fff',
+      bgcolor: disabled ? 'action.disabledBackground' : 'background.paper',
       border: '1px dashed',
       borderColor: touched && error ? 'error.main' : 'divider',
       transition: '0.2s ease',
@@ -158,7 +158,7 @@ const SmartFileInput = forwardRef<SmartFileInputRef, SmartFileInputProps>(({
       <Box sx={{
         width: 60,
         height: 60,
-        backgroundColor: '#f1f1f1',
+        backgroundColor: 'grey.100',
         borderRadius: 2,
         display: 'flex',
         alignItems: 'center',

--- a/src/common/components/ui/Layout/index.tsx
+++ b/src/common/components/ui/Layout/index.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   const drawerWidth = isMobile ? 0 : 75
 
   return (
-    <Box sx={{ display: 'flex', minHeight: '100vh', bgcolor: '#ecf5f9' }}>
+    <Box sx={{ display: 'flex', minHeight: '100vh', bgcolor: 'background.default' }}>
       <ToastProvider>
         <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={es}>
           <CssBaseline />

--- a/src/common/components/ui/Navbar/AppHeader.tsx
+++ b/src/common/components/ui/Navbar/AppHeader.tsx
@@ -9,6 +9,7 @@ import {
 
 import SearchActivator from '../SearchBar/SearchActivator';
 import UserMenu from './UserMenu';
+import ThemeToggle from './ThemeToggle'
 
 export default function AppHeader() {
   const theme = useTheme();
@@ -43,6 +44,7 @@ export default function AppHeader() {
         disableGutters
         sx={{ justifyContent: 'space-between', minHeight: 64, px: 2, zIndex: 10 }}>
         <SearchActivator />
+        <ThemeToggle />
         <UserMenu />
       </Toolbar>
     </AppBar>

--- a/src/common/components/ui/Navbar/ThemeToggle.tsx
+++ b/src/common/components/ui/Navbar/ThemeToggle.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import React from 'react'
+import { IconButton, Tooltip, useTheme } from '@mui/material'
+import DarkModeOutlinedIcon from '@mui/icons-material/DarkModeOutlined'
+import LightModeOutlinedIcon from '@mui/icons-material/LightModeOutlined'
+import { useColorMode } from '@/common/hooks'
+
+export default function ThemeToggle() {
+  const { toggleColorMode, mode } = useColorMode()
+  const theme = useTheme()
+
+  return (
+    <Tooltip
+      title={mode === 'light' ? 'Activar modo oscuro' : 'Desactivar modo oscuro'}
+    >
+      <IconButton onClick={toggleColorMode} sx={{ color: theme.palette.text.primary }}>
+        {mode === 'light' ? <DarkModeOutlinedIcon /> : <LightModeOutlinedIcon />}
+      </IconButton>
+    </Tooltip>
+  )
+}

--- a/src/common/components/ui/SideMenu/styles.ts
+++ b/src/common/components/ui/SideMenu/styles.ts
@@ -6,9 +6,10 @@ export const SidebarContainer = styled(motion.aside)(({ theme }) => ({
   height: '100vh',
   position: 'fixed',
   left: 0,
-  background: theme.palette.mode === 'dark'
-    ? theme.palette.background.default
-    : 'linear-gradient(180deg, #ffffff 0%, #f9f9f9 100%)',
+  background:
+    theme.palette.mode === 'dark'
+      ? theme.palette.background.default
+      : `linear-gradient(180deg, ${theme.palette.background.paper} 0%, ${theme.palette.grey[50]} 100%)`,
   backdropFilter: 'blur(12px)',
   boxShadow: '4px 0 20px rgba(0,0,0,0.06)',
   zIndex: 1101,

--- a/src/common/hooks/index.ts
+++ b/src/common/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useAppDispatch } from "./useAppDispatch";
 export { useAppSelector } from "./useAppSelector";
 export { useSessionExpiration } from "./useSessionExpiration";
+export { useColorMode } from "./useColorMode";

--- a/src/common/hooks/useColorMode.ts
+++ b/src/common/hooks/useColorMode.ts
@@ -1,0 +1,4 @@
+import { useContext } from 'react'
+import { ColorModeContext } from '@/common/components/ColorModeProvider'
+
+export const useColorMode = () => useContext(ColorModeContext)

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -1,184 +1,111 @@
-import { createTheme } from '@mui/material/styles';
+import { PaletteMode, createTheme } from '@mui/material'
 
-const fullTheme = createTheme({
-  palette: {
-    mode: 'light',
+const commonTokens = {
+  typography: {
+    fontFamily: `'Inter', 'Roboto', 'Segoe UI', 'Helvetica Neue', sans-serif`,
+    fontSize: 14,
+    h1: { fontSize: '3rem', fontWeight: 700 },
+    h2: { fontSize: '2.25rem', fontWeight: 700 },
+    h3: { fontSize: '1.75rem', fontWeight: 700 },
+    h4: { fontSize: '1.5rem', fontWeight: 600 },
+    h5: { fontSize: '1.25rem', fontWeight: 600 },
+    h6: { fontSize: '1rem', fontWeight: 600 },
+    body1: { fontSize: '1rem' },
+    body2: { fontSize: '0.875rem' },
+    button: { textTransform: 'none', fontWeight: 500 },
+    caption: { fontSize: '0.75rem' },
+  },
+  shape: { borderRadius: 10 },
+  spacing: 8,
+  shadows: Array(25).fill('0px 2px 6px rgba(0, 0, 0, 0.06)') as string[],
+  breakpoints: { values: { xs: 0, sm: 600, md: 960, lg: 1280, xl: 1536 } },
+}
+
+export const createCustomTheme = (mode: PaletteMode) => {
+  const palette = {
+    mode,
     primary: {
-      main: '#0F4C81',     
+      main: '#0F4C81',
       light: '#6EA8E5',
       dark: '#062B4F',
       contrastText: '#ffffff',
-      
     },
     secondary: {
-      main: '#C8102E',       // Rojo vibrante elegante
+      main: '#C8102E',
       light: '#F2546D',
       dark: '#900021',
       contrastText: '#ffffff',
     },
-    error: {
-      main: '#D32F2F',
-      contrastText: '#ffffff',
-    },
-    warning: {
-      main: '#FFA000',
-      contrastText: '#212121',
-    },
-    info: {
-      main: '#0288D1',
-      contrastText: '#ffffff',
-    },
-    success: {
-      main: '#43A047',
-      contrastText: '#ffffff',
-    },
-    background: {
-      default: '#F8FAFF',
-      paper: '#ffffff',
-    },
-    text: {
-      primary: '#02395B',
-      secondary: '#2E4053',
-      disabled: '#A3A3A3',
-    },
-    divider: '#E0E0E0',
-    grey: {
-      50: '#F9FAFB',
-      100: '#F3F4F6',
-      200: '#E5E7EB',
-      300: '#D1D5DB',
-      400: '#9CA3AF',
-      500: '#6B7280',
-      600: '#4B5563',
-      700: '#374151',
-      800: '#1F2937',
-      900: '#111827',
-    },
-  },
-  typography: {
-    fontFamily: `'Inter', 'Roboto', 'Segoe UI', 'Helvetica Neue', sans-serif`,
-    fontSize: 14,
-    h1: {
-      fontSize: '3rem',
-      fontWeight: 700,
-    },
-    h2: {
-      fontSize: '2.25rem',
-      fontWeight: 700,
-    },
-    h3: {
-      fontSize: '1.75rem',
-      fontWeight: 700,
-    },
-    h4: {
-      fontSize: '1.5rem',
-      fontWeight: 600,
-    },
-    h5: {
-      fontSize: '1.25rem',
-      fontWeight: 600,
-    },
-    h6: {
-      fontSize: '1rem',
-      fontWeight: 600,
-    },
-    body1: {
-      fontSize: '1rem',
-      color: '#333',
-    },
-    body2: {
-      fontSize: '0.875rem',
-      color: '#555F75',
-    },
-    button: {
-      textTransform: 'none',
-      fontWeight: 500,
-    },
-    caption: {
-      fontSize: '0.75rem',
-      color: '#A3A3A3',
-    },
-  },
-  shape: {
-    borderRadius: 10,
-  },
-  spacing: 8,
-  shadows: [
-    "none",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)",
-    "0px 2px 6px rgba(0, 0, 0, 0.06)"
-  ],
-  breakpoints: {
-    values: {
-      xs: 0,
-      sm: 600,
-      md: 960,
-      lg: 1280,
-      xl: 1536,
-    },
-  },
-  components: {
-    MuiCssBaseline: {
-      styleOverrides: {
-        body: {
-          backgroundColor: '#F8FAFF',
-        },
-      },
-    },
-    MuiButton: {
-      styleOverrides: {
-        root: {
-          borderRadius: 8,
-          fontWeight: 500,
-        },
-      },
-    },
-    MuiPaper: {
-      styleOverrides: {
-        root: {
-          borderRadius: 10,
-        },
-      },
-    },
-    MuiAppBar: {
-      styleOverrides: {
-        root: {
-          backgroundColor: '#ffffff',
-          color: '#1A1A1A',
-          boxShadow: '0 1px 4px rgba(0,0,0,0.05)',
-        },
-      },
-    },
-    MuiDrawer: {
-      styleOverrides: {
-        paper: {
-          backgroundColor: '#ffffff',
-        },
-      },
-    },
-  },
-});
+    error: { main: '#D32F2F', contrastText: '#ffffff' },
+    warning: { main: '#FFA000', contrastText: '#212121' },
+    info: { main: '#0288D1', contrastText: '#ffffff' },
+    success: { main: '#43A047', contrastText: '#ffffff' },
+    ...(mode === 'light'
+      ? {
+          background: { default: '#F8FAFF', paper: '#ffffff' },
+          text: { primary: '#02395B', secondary: '#2E4053', disabled: '#A3A3A3' },
+          divider: '#E0E0E0',
+          grey: {
+            50: '#F9FAFB',
+            100: '#F3F4F6',
+            200: '#E5E7EB',
+            300: '#D1D5DB',
+            400: '#9CA3AF',
+            500: '#6B7280',
+            600: '#4B5563',
+            700: '#374151',
+            800: '#1F2937',
+            900: '#111827',
+          },
+        }
+      : {
+          background: { default: '#0e1721', paper: '#1d2733' },
+          text: { primary: '#f3f3f3', secondary: '#cfd8dc', disabled: '#7c8691' },
+          divider: 'rgba(255,255,255,0.12)',
+          grey: {
+            50: '#fafafa',
+            100: '#f5f5f5',
+            200: '#eeeeee',
+            300: '#e0e0e0',
+            400: '#bdbdbd',
+            500: '#9e9e9e',
+            600: '#757575',
+            700: '#616161',
+            800: '#424242',
+            900: '#212121',
+          },
+        }),
+  }
 
-export default fullTheme;
+  const base = createTheme({ palette, ...commonTokens })
+
+  return createTheme(base, {
+    components: {
+      MuiCssBaseline: {
+        styleOverrides: {
+          body: { backgroundColor: base.palette.background.default },
+        },
+      },
+      MuiButton: {
+        styleOverrides: { root: { borderRadius: 8, fontWeight: 500 } },
+      },
+      MuiPaper: {
+        styleOverrides: { root: { borderRadius: 10 } },
+      },
+      MuiAppBar: {
+        styleOverrides: {
+          root: {
+            backgroundColor: base.palette.background.paper,
+            color: base.palette.text.primary,
+            boxShadow: '0 1px 4px rgba(0,0,0,0.05)',
+          },
+        },
+      },
+      MuiDrawer: {
+        styleOverrides: {
+          paper: { backgroundColor: base.palette.background.paper },
+        },
+      },
+    },
+  })
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,15 +2,14 @@ import "../styles/main.css";
 import Head from "next/head";
 import type { AppProps } from "next/app";
 
-import fullTheme from '@/config/theme';
-import { ThemeProvider } from '@mui/material/styles';
+import ColorModeProvider from '@/common/components/ColorModeProvider'
 import { Provider } from 'react-redux';
 import { store, persistor } from '@/config/store';
 import { PersistGate } from 'redux-persist/integration/react';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <ThemeProvider theme={fullTheme}>
+    <ColorModeProvider>
       <Provider store={store}>
         <PersistGate loading={null} persistor={persistor}>
           <Head>
@@ -19,7 +18,7 @@ export default function App({ Component, pageProps }: AppProps) {
           <Component {...pageProps} />
         </PersistGate>
       </Provider>
-    </ThemeProvider>
+    </ColorModeProvider>
   );
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,7 +23,7 @@ export default function Home() {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <main style={{ backgroundColor: '#f9f9fb', minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <Box component="main" sx={{ bgcolor: 'background.default', minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
         
         {/* Hero Section */}
         <Box flex={1}>
@@ -101,12 +101,12 @@ export default function Home() {
         </Box>
 
         {/* Footer */}
-        <Box sx={{ py: 4, textAlign: 'center', backgroundColor: '#f1f1f1', color: 'text.secondary' }} component="footer">
+        <Box sx={{ py: 4, textAlign: 'center', backgroundColor: 'grey.100', color: 'text.secondary' }} component="footer">
           <Typography variant="body2">
             © {new Date().getFullYear()} Avan. Todos los derechos reservados.
           </Typography>
         </Box>
-      </main>
+      </Box>
     </>
   )
 }


### PR DESCRIPTION
## Summary
- añadir ColorModeProvider y hook `useColorMode`
- generar tema dinámico con soporte `light` y `dark`
- integrar provider en `_app`
- agregar botón de cambio de tema en la barra de navegación
- homogeneizar colores usando el theme en varios componentes y páginas

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6851992cd724833088fd8a973b017dcc