### PR TITLE
Add theme-aware icons

### DIFF
--- a/src/common/components/SmartFilter/SmartFilterButtons.tsx
+++ b/src/common/components/SmartFilter/SmartFilterButtons.tsx
@@ -20,6 +20,8 @@ import {
   useTheme
 } from '@mui/material'
 
+import ThemedIcon from '../ThemedIcon'
+
 import DownloadIcon from '@mui/icons-material/Download'
 import ViewColumnIcon from '@mui/icons-material/ViewColumn'
 
@@ -74,7 +76,7 @@ export default function SmartFilterButtons({
         {/* Filtros */}
         <Tooltip title="Filtros avanzados">
           <IconButton onClick={(e) => setAnchorEl(e.currentTarget)} size="small">
-            <img src="/assets/svg/options-outline.svg" alt="Filtros" width={20} />
+            <ThemedIcon src="/assets/svg/options-outline.svg" alt="Filtros" width={20} />
           </IconButton>
         </Tooltip>
 

--- a/src/common/components/SmartFilter/SmartFilterInput.tsx
+++ b/src/common/components/SmartFilter/SmartFilterInput.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react'
 import { TextField, InputAdornment, IconButton } from '@mui/material'
+import ThemedIcon from '../ThemedIcon'
 
 interface Props {
   value: string
@@ -29,7 +30,7 @@ export default function SmartFilterInput({ value, onChange, onSearch, placeholde
               edge="end"
               size="small"
               aria-label="Buscar">
-              <img src="/assets/svg/search-outline.svg" alt="buscar" width={18} />
+              <ThemedIcon src="/assets/svg/search-outline.svg" alt="buscar" width={18} />
             </IconButton>
           </InputAdornment>
         )

--- a/src/common/components/SmartInput/index.tsx
+++ b/src/common/components/SmartInput/index.tsx
@@ -14,6 +14,7 @@ import {
   Typography,
   Box
 } from '@mui/material';
+import ThemedIcon from '../ThemedIcon';
 
 export interface SmartInputRef {
   isValid: () => boolean;
@@ -164,9 +165,9 @@ const SmartInputComponent = memo(forwardRef<SmartInputRef, SmartInputProps>((pro
                 disabled={disabled}
               >
                 {showPassword ? (
-                  <img src="/assets/svg/eye-off-outline.svg" alt="ocultar" width="20" />
+                  <ThemedIcon src="/assets/svg/eye-off-outline.svg" alt="ocultar" width={20} />
                 ) : (
-                  <img src="/assets/svg/eye-outline.svg" alt="mostrar" width="20" />
+                  <ThemedIcon src="/assets/svg/eye-outline.svg" alt="mostrar" width={20} />
                 )}
               </IconButton>
             </InputAdornment>

--- a/src/common/components/ThemedIcon.tsx
+++ b/src/common/components/ThemedIcon.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { useTheme } from '@mui/material'
+
+interface ThemedIconProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  src: string
+  alt: string
+}
+
+export default function ThemedIcon({ src, alt, style, ...rest }: ThemedIconProps) {
+  const theme = useTheme()
+  const filter = theme.palette.mode === 'dark' ? 'invert(1)' : 'none'
+  return <img src={src} alt={alt} style={{ filter, ...style }} {...rest} />
+}

--- a/src/common/components/index.ts
+++ b/src/common/components/index.ts
@@ -8,7 +8,8 @@ import ConfirmModal from "./ConfirmModal";
 import ModalForm from "./ModalForm";
 import SmartFileInput from "./SmartFileInput";
 import { ToastProvider } from "./ToastProvider";
+import ThemedIcon from "./ThemedIcon";
 
 
-export { SmartButton, SmartInput, SmartTable, Header, Modal, ConfirmModal, ModalForm, SmartSelect, ToastProvider };
+export { SmartButton, SmartInput, SmartTable, Header, Modal, ConfirmModal, ModalForm, SmartSelect, ToastProvider, ThemedIcon };
 export type { SmartInputRef };

--- a/src/modules/auth/index.tsx
+++ b/src/modules/auth/index.tsx
@@ -8,7 +8,7 @@ import Router from "next/router";
 import { Stack, Typography, Paper, useTheme, useMediaQuery } from "@mui/material";
 
 // Commons
-import { SmartButton, SmartInput, SmartInputRef } from "@/common/components";
+import { SmartButton, SmartInput, SmartInputRef, ThemedIcon } from "@/common/components";
 import { useAppDispatch } from '@/common/hooks';
 import { setCurrentUser } from "@/common/utils";
 
@@ -90,7 +90,7 @@ export default function AuthModule() {
           label="Correo electrónico"
           placeholder="Escribe tu correo electrónico"
           name="email"
-          leftIcon={<img src="/assets/svg/person-circle-outline.svg" alt="correo" width="20" />}
+          leftIcon={<ThemedIcon src="/assets/svg/person-circle-outline.svg" alt="correo" width={20} />}
           size="small"
         />
 
@@ -101,7 +101,7 @@ export default function AuthModule() {
           placeholder="Escribe tu contraseña"
           name="password"
           type="password"
-          leftIcon={<img src="/assets/svg/lock-closed-outline.svg" alt="contraseña" width="20" />}
+          leftIcon={<ThemedIcon src="/assets/svg/lock-closed-outline.svg" alt="contraseña" width={20} />}
           size="small"
         />
 

--- a/src/modules/role/ui/ProfileView.tsx
+++ b/src/modules/role/ui/ProfileView.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, Fragment } from "react";
 import AddIcon from "@mui/icons-material/Add";
 import AssignmentIndIcon from '@mui/icons-material/AssignmentInd';
 
-import { SmartTable, Header, SmartButton, ModalForm, ConfirmModal } from "@/common/components";
+import { SmartTable, Header, SmartButton, ModalForm, ConfirmModal, ThemedIcon } from "@/common/components";
 import { getAllowedActions } from "@/common/utils";
 
 import { useProfileController } from "../application/useProfileController";
@@ -79,7 +79,7 @@ export function ProfileView() {
               if (row?.status === "ELIMINADO") return true
               return !getAllowedActions("role_edit")
             },
-            icon: <img src="/assets/svg/create-outline.svg" alt="edit" width="20" />,
+            icon: <ThemedIcon src="/assets/svg/create-outline.svg" alt="edit" width={20} />,
             onClick: handleEdit,
           },
           {
@@ -88,7 +88,7 @@ export function ProfileView() {
               if (row?.status === "ELIMINADO") return true
               return !getAllowedActions('role_permission_edit')
             },
-            icon: <img src="/assets/svg/settings-outline.svg" alt="permissions" width="20" />,
+            icon: <ThemedIcon src="/assets/svg/settings-outline.svg" alt="permissions" width={20} />,
             onClick: (row) => handleRequestEdit(row, catalogs),
           },
           {
@@ -97,7 +97,7 @@ export function ProfileView() {
               if (row?.status === "ELIMINADO") return true
               return !getAllowedActions('role_edit')
             },
-            icon: <img src="/assets/svg/trash-outline.svg" alt="delete" width="20" />,
+            icon: <ThemedIcon src="/assets/svg/trash-outline.svg" alt="delete" width={20} />,
             onClick: handleDelete,
           },
         ]}

--- a/src/modules/session/ui/SessionView.tsx
+++ b/src/modules/session/ui/SessionView.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, Fragment } from "react";
 import Settings from "@mui/icons-material/Settings";
 
-import { SmartTable, Header, ConfirmModal } from "@/common/components";
+import { SmartTable, Header, ConfirmModal, ThemedIcon } from "@/common/components";
 
 import { useSessionController } from "../application/useSessionController";
 import { useSessionUI } from "../application/useSessionUI";
@@ -53,13 +53,13 @@ export function SessionView() {
           {
             label: "Ban",
             hidden: !getAllowedActions("user_edit"),
-            icon: <img src="/assets/svg/ban-outline.svg" alt="active" width="20" />,
+            icon: <ThemedIcon src="/assets/svg/ban-outline.svg" alt="active" width={20} />,
             onClick: handleBan
           },
           {
             label: "Eliminar",
             hidden: !getAllowedActions("user_edit"),
-            icon: <img src="/assets/svg/trash-outline.svg" alt="delete" width="20" />,
+            icon: <ThemedIcon src="/assets/svg/trash-outline.svg" alt="delete" width={20} />,
             onClick: handleDelete
           },
         ]}

--- a/src/modules/user/ui/UserView.tsx
+++ b/src/modules/user/ui/UserView.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, Fragment } from "react";
 import AddIcon from "@mui/icons-material/Add";
 import SwitchAccountRoundedIcon from "@mui/icons-material/SwitchAccountRounded";
 
-import { SmartTable, Header, SmartButton, ModalForm, ConfirmModal } from "@/common/components";
+import { SmartTable, Header, SmartButton, ModalForm, ConfirmModal, ThemedIcon } from "@/common/components";
 
 import { useUserController } from "../application/useUserController";
 import { useUserUI } from "../application/useUserUI";
@@ -85,7 +85,7 @@ export function UserView() {
               if (row?.status === "ELIMINADO") return true
               return !getAllowedActions("user_edit")
             },
-            icon: <img src="/assets/svg/create-outline.svg" alt="edit" width="20" />,
+            icon: <ThemedIcon src="/assets/svg/create-outline.svg" alt="edit" width={20} />,
             onClick: handleEdit
           },
           {
@@ -94,13 +94,13 @@ export function UserView() {
               if (row?.status === "ACTIVO") return true
               return !getAllowedActions("user_edit")
             },
-            icon: <img src="/assets/svg/checkmark-circle-outline.svg" alt="active" width="20" />,
+            icon: <ThemedIcon src="/assets/svg/checkmark-circle-outline.svg" alt="active" width={20} />,
             onClick: handleActive
           },
           {
             label: "Eliminar",
             hidden: !getAllowedActions("user_edit"),
-            icon: <img src="/assets/svg/trash-outline.svg" alt="delete" width="20" />,
+            icon: <ThemedIcon src="/assets/svg/trash-outline.svg" alt="delete" width={20} />,
             onClick: handleDelete
           },
         ]}

--- a/src/pages/auth/forgot-password.tsx
+++ b/src/pages/auth/forgot-password.tsx
@@ -7,7 +7,7 @@ import Router from "next/router";
 import { Stack, Typography, Paper, useTheme, useMediaQuery } from "@mui/material";
 
 // Commons
-import { SmartButton, SmartInput, SmartInputRef } from "@/common/components";
+import { SmartButton, SmartInput, SmartInputRef, ThemedIcon } from "@/common/components";
 
 // Services
 import { forgotPassword } from "@/modules/auth/auth.services";
@@ -85,7 +85,7 @@ export default function AuthModule() {
             label="Correo"
             placeholder="Escribe tu correo"
             name="email"
-            leftIcon={<img src="/assets/svg/person-circle-outline.svg" alt="correo" width="20" />}
+            leftIcon={<ThemedIcon src="/assets/svg/person-circle-outline.svg" alt="correo" width={20} />}
             size="small"
           />
 


### PR DESCRIPTION
## Summary
- add ThemedIcon component to change svg colors based on theme mode
- use ThemedIcon across inputs, filters, and table actions

## Testing
- `npm run lint`
- `npm run build` *(fails: type error in theme.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6851b130ff288330b39520e6ed506792