### PR TITLE
Improve sidebar UX

### DIFF
--- a/src/common/components/ui/SideMenu/DrawerContent.tsx
+++ b/src/common/components/ui/SideMenu/DrawerContent.tsx
@@ -2,7 +2,8 @@
 'use client'
 
 import React, { useState, useCallback } from 'react'
-import { Box, List } from '@mui/material'
+import { Box, List, useTheme } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import { usePathname } from 'next/navigation'
 
 import { useDrawerContent } from './useDrawerContent'
@@ -15,6 +16,7 @@ export default function DrawerContent() {
   const pathname = usePathname()
   const [hovered, setHovered] = useState(false)
   const [openSubmenus, setOpenSubmenus] = useState<Record<string, boolean>>({})
+  const theme = useTheme()
 
   const toggleSubmenu = useCallback((label: string) => {
     setOpenSubmenus(prev => ({ ...prev, [label]: !prev[label] }))
@@ -33,7 +35,9 @@ export default function DrawerContent() {
             left: 0,
             width: '100vw',
             height: '100vh',
-            backgroundColor: 'rgba(0, 0, 0, 0.35)',
+            backgroundColor: theme.palette.mode === 'dark'
+              ? alpha(theme.palette.common.black, 0.5)
+              : alpha(theme.palette.common.black, 0.35),
             zIndex: 1100,
           }}
         />

--- a/src/common/components/ui/SideMenu/styles.ts
+++ b/src/common/components/ui/SideMenu/styles.ts
@@ -9,10 +9,11 @@ export const SidebarContainer = styled(motion.aside)(({ theme }) => ({
   width: 72,
   background:
     theme.palette.mode === 'dark'
-      ? theme.palette.background.paper
-      : `linear-gradient(180deg, ${theme.palette.background.paper} 0%, ${theme.palette.grey[100]} 100%)`,
-  backdropFilter: 'blur(14px)',
+      ? `linear-gradient(180deg, ${theme.palette.background.paper} 0%, ${theme.palette.grey[800]} 100%)`
+      : `linear-gradient(180deg, ${theme.palette.background.paper} 0%, ${theme.palette.grey[50]} 100%)`,
+  backdropFilter: 'blur(16px)',
   boxShadow: '4px 0 24px rgba(0,0,0,0.08)',
+  borderRight: `1px solid ${theme.palette.divider}`,
   zIndex: 1101,
   overflowX: 'hidden',
   transition: 'background-color 0.3s ease, box-shadow 0.3s ease',
@@ -21,7 +22,7 @@ export const SidebarContainer = styled(motion.aside)(({ theme }) => ({
 export const NavLinkStyled = styled(ListItemButton)(({ theme }) => ({
   borderRadius: theme.shape.borderRadius,
   padding: theme.spacing(1, 2),
-  margin: theme.spacing(0, 0),
+  margin: theme.spacing(0.5, 0),
   gap: theme.spacing(1.5),
   transition: 'all 0.25s ease',
   position: 'relative',
@@ -41,21 +42,23 @@ export const NavLinkStyled = styled(ListItemButton)(({ theme }) => ({
   },
 
   '&:hover': {
-    backgroundColor: theme.palette.action.hover,
+    backgroundColor:
+      theme.palette.mode === 'dark'
+        ? alpha(theme.palette.primary.main, 0.12)
+        : alpha(theme.palette.primary.main, 0.06),
     transform: 'translateX(4px)',
     color: theme.palette.text.primary,
+    boxShadow: theme.shadows[1],
   },
 
   '&.active': {
-    backgroundColor:
-      theme.palette.mode === 'dark'
-        ? alpha(theme.palette.primary.main, 0.15)
-        : alpha(theme.palette.primary.main, 0.1),
+    backgroundImage: `linear-gradient(90deg, ${alpha(theme.palette.primary.light, 0.3)} 0%, ${alpha(theme.palette.primary.main, 0.3)} 100%)`,
     color: theme.palette.primary.main,
     fontWeight: theme.typography.fontWeightMedium,
     '&::before': {
       backgroundColor: theme.palette.primary.main,
     },
+    boxShadow: theme.shadows[2],
   },
 }));
 
@@ -63,5 +66,6 @@ export const SubMenuArrow = styled(motion.span)(({ theme }) => ({
   marginLeft: 'auto',
   fontSize: '1rem',
   color: theme.palette.text.secondary,
+  transition: 'transform 0.25s ease',
 }));
 


### PR DESCRIPTION
## Summary
- refine sidebar container background and add divider
- enhance nav item hover and active effects
- apply gradient to active items and subtle shadows
- update overlay color in `DrawerContent`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852fb1f82488330b10cf1ff4d4c7da1