### PR TITLE
Fix hydration error caused by ul in Typography

### DIFF
--- a/src/common/components/ToastProvider/index.tsx
+++ b/src/common/components/ToastProvider/index.tsx
@@ -140,7 +140,7 @@ export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
                 </AnimatePresence>
               </Box>
 
-              <Typography variant="body2" fontWeight={500} flex={1}>
+              <Typography component="div" variant="body2" fontWeight={500} flex={1}>
                 {message.title}
                 <br />
                 <Box component="ul" sx={{ m: 0 }}>


### PR DESCRIPTION
## Summary
- stop rendering Typography as `<p>` when containing a `<ul>`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68561d0193e483308e4b4545046b4e29