### PR TITLE
Add offline development mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Cada módulo dentro de `src/modules` sigue un pequeño esquema en capas (`domain
 
 ```bash
 npm run dev
+# o bien
+npm run dev:offline
 ```
 
 La aplicación quedará disponible en `http://localhost:3000` por defecto.
@@ -38,6 +40,7 @@ La aplicación quedará disponible en `http://localhost:3000` por defecto.
 ## Comandos disponibles
 
 - `npm run dev` &mdash; Levanta el servidor de desarrollo con Turbopack.
+- `npm run dev:offline` &mdash; Ejecuta el modo sin API usando datos de ejemplo.
 - `npm run build` &mdash; Genera la versión optimizada para producción.
 - `npm run start` &mdash; Ejecuta la app ya compilada.
 - `npm run lint` &mdash; Revisa la calidad del código con ESLint.

--- a/env.EXAMPLE
+++ b/env.EXAMPLE
@@ -1,4 +1,6 @@
 NEXT_PUBLIC_API_URL="http://localhost:3001/api"
+NEXT_PUBLIC_OFFLINE_MODE="false"
 
 JWT_SECRET="secret"
 NODE_ENV="development"
+

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
+    "dev:offline": "NEXT_PUBLIC_OFFLINE_MODE=true next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/src/common/components/ui/SideMenu/useDrawerContent.tsx
+++ b/src/common/components/ui/SideMenu/useDrawerContent.tsx
@@ -5,16 +5,20 @@ import { modulesList } from '@/config/routes'
 import { getCurrentUser } from '@/common/utils'
 
 export function useDrawerContent() {
+  const offline = process.env.NEXT_PUBLIC_OFFLINE_MODE === 'true'
   const menuItems: IMenuItem[] = useMemo(() => {
+    if (offline) return modulesList
+
     const currentUser = getCurrentUser()
     if (!currentUser) return []
 
     const hasPermission = (perm?: string) =>
       currentUser.allowedPermissions.includes(perm ?? '')
 
-    const modules = modulesList.filter(item =>
-      !item.submenu &&
-      (hasPermission(item.permission) || item.permission === 'dashboard')
+    const modules = modulesList.filter(
+      item =>
+        !item.submenu &&
+        (hasPermission(item.permission) || item.permission === 'dashboard')
     )
 
     const subModules = modulesList
@@ -28,7 +32,7 @@ export function useDrawerContent() {
       .filter(Boolean) as IMenuItem[]
 
     return [...modules, ...subModules]
-  }, [])
+  }, [offline])
 
   return {
     menuItems

--- a/src/common/libs/api-services.ts
+++ b/src/common/libs/api-services.ts
@@ -8,7 +8,10 @@ import axios, {
 import { getCurrentUser } from '../utils';
 import { handleSessionExpired } from '@/common/utils';
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL || '';
+const BASE_URL =
+  process.env.NEXT_PUBLIC_OFFLINE_MODE === 'true'
+    ? '/api/mock'
+    : process.env.NEXT_PUBLIC_API_URL || '';
 
 export interface RequestOptions {
   params?: Record<string, any>;

--- a/src/common/libs/page-permissions.tsx
+++ b/src/common/libs/page-permissions.tsx
@@ -14,20 +14,23 @@ export default function withPermissionGuard<P extends JSX.IntrinsicAttributes>(
     const user = useSelector((state: RootState) => state.auth.currentUser);
     const [authorized, setAuthorized] = useState(false);
 
+    const offline = process.env.NEXT_PUBLIC_OFFLINE_MODE === 'true';
+
     const hasPermission = useMemo(() => {
+      if (offline) return true;
       return !!user?.allowedPermissions?.includes(requiredPermission);
-    }, [user, requiredPermission]);
+    }, [user, requiredPermission, offline]);
 
     useEffect(() => {
       if (!user) return;
 
       if (!hasPermission) {
-        router.replace('/404'); 
+        router.replace('/404');
         setAuthorized(false);
       } else {
         setAuthorized(true);
       }
-    }, [hasPermission, user]);
+    }, [hasPermission, user, router]);
 
     if (!authorized) return null;
 

--- a/src/common/utils/current-user.ts
+++ b/src/common/utils/current-user.ts
@@ -39,6 +39,9 @@ export function clearCurrentUser() {
 };
 
 export function getAllowedActions(method: string): boolean {
+  if (process.env.NEXT_PUBLIC_OFFLINE_MODE === 'true') {
+    return true;
+  }
   if (!getCurrentUser()) return false;
   const { allowedPermissions } = getCurrentUser()!;
   return !!allowedPermissions.includes(method);

--- a/src/pages/api/mock/administration/roles/index.ts
+++ b/src/pages/api/mock/administration/roles/index.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+const roles = [
+  {
+    roleId: 1,
+    roleName: 'Administrador',
+    status: 'ACTIVO',
+    permissions: [
+      { permissionId: 1, permissionName: 'user_create' },
+      { permissionId: 2, permissionName: 'user_edit' },
+      { permissionId: 3, permissionName: 'session_view' },
+    ],
+    createdAt: new Date().toISOString(),
+  },
+  {
+    roleId: 2,
+    roleName: 'Invitado',
+    status: 'ACTIVO',
+    permissions: [],
+    createdAt: new Date().toISOString(),
+  },
+]
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    return res.status(200).json({ data: roles })
+  }
+
+  return res.status(200).json({ data: {} })
+}

--- a/src/pages/api/mock/administration/roles/permissions.ts
+++ b/src/pages/api/mock/administration/roles/permissions.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+const permissions = [
+  { permissionId: 1, permissionName: 'user_create' },
+  { permissionId: 2, permissionName: 'user_edit' },
+  { permissionId: 3, permissionName: 'session_view' },
+]
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    return res.status(200).json({ data: permissions })
+  }
+
+  return res.status(200).json({ data: {} })
+}

--- a/src/pages/api/mock/administration/users/index.ts
+++ b/src/pages/api/mock/administration/users/index.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+const users = [
+  {
+    userId: 1,
+    email: 'demo@example.com',
+    username: 'Demo User',
+    roleId: 1,
+    roleName: 'Administrador',
+    status: 'ACTIVO',
+    createdAt: new Date().toISOString(),
+  },
+  {
+    userId: 2,
+    email: 'test@example.com',
+    username: 'Test User',
+    roleId: 2,
+    roleName: 'Invitado',
+    status: 'INACTIVO',
+    createdAt: new Date().toISOString(),
+  },
+]
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    return res.status(200).json({ data: users })
+  }
+
+  return res.status(200).json({ data: {} })
+}

--- a/src/pages/api/mock/auth/login.ts
+++ b/src/pages/api/mock/auth/login.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' })
+  }
+
+  const user = {
+    userId: 1,
+    email: 'demo@example.com',
+    code: 'USER001',
+    username: 'Demo User',
+    status: 'ACTIVO',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    token: 'mock-token',
+    role: {
+      roleId: 1,
+      roleName: 'Administrador',
+      status: 'ACTIVO',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      permissions: [
+        { permissionId: 1, permissionName: 'user_create' },
+        { permissionId: 2, permissionName: 'user_edit' },
+        { permissionId: 3, permissionName: 'session_view' }
+      ]
+    }
+  }
+
+  return res.status(200).json({ data: user })
+}

--- a/src/pages/api/mock/sessions/ban-session.ts
+++ b/src/pages/api/mock/sessions/ban-session.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'PUT') {
+    return res.status(200).json({ data: {} })
+  }
+
+  return res.status(405).json({ message: 'Method not allowed' })
+}

--- a/src/pages/api/mock/sessions/close-session.ts
+++ b/src/pages/api/mock/sessions/close-session.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'PUT' || req.method === 'DELETE') {
+    return res.status(200).json({ data: {} })
+  }
+
+  return res.status(405).json({ message: 'Method not allowed' })
+}

--- a/src/pages/api/mock/sessions/index.ts
+++ b/src/pages/api/mock/sessions/index.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+const sessions = [
+  {
+    sessionId: 1,
+    userId: 1,
+    device: 'Chrome',
+    ip: '127.0.0.1',
+    status: 'ACTIVO',
+    createdAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 3600 * 1000).toISOString(),
+    user: {
+      username: 'Demo User',
+    },
+  },
+]
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    return res.status(200).json({ data: sessions })
+  }
+
+  return res.status(200).json({ data: {} })
+}


### PR DESCRIPTION
## Summary
- allow running frontend without the backend API
- create mock API routes
- switch API base URL when `NEXT_PUBLIC_OFFLINE_MODE` is set
- document new `dev:offline` command
- disable all permission checks for easier offline development
- respect permissions only when not in offline mode

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6857925659cc8330a6b3594901ced23e