### PR TITLE
Improve ModalForm with react-hook-form

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-redux": "^9.2.0",
-    "redux-persist": "^6.0.0"
+    "redux-persist": "^6.0.0",
+    "react-hook-form": "^7.51.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/common/components/ModalForm/FieldRenderer.tsx
+++ b/src/common/components/ModalForm/FieldRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { memo, forwardRef } from 'react';
+import React, { memo } from 'react';
 import SmartInput from '../SmartInput';
 import SmartSelect from '../SmartSelect';
 import SmartFileInput from '../SmartFileInput';
@@ -11,16 +11,15 @@ import { FieldSchema } from './types';
 interface FieldRendererProps {
   field: FieldSchema;
   defaultValue: any;
-  onRef: (ref: any) => void;
+  onChange: (value: any) => void;
 }
 
-function FieldRendererComponent({ field, defaultValue, onRef }: FieldRendererProps) {
+function FieldRendererComponent({ field, defaultValue, onChange }: FieldRendererProps) {
   const {
     label,
     type = 'text',
     required,
     placeholder,
-    onChange,
     options = [],
     allowedFormats,
     maxFileSizeMB,
@@ -31,10 +30,17 @@ function FieldRendererComponent({ field, defaultValue, onRef }: FieldRendererPro
     disabled
   } = field;
 
+
   if (type === 'checkbox') {
     return (
       <FormControlLabel
-        control={<Checkbox defaultChecked={!!defaultValue} disabled={!!disabled} onChange={onChange} />}
+        control={
+          <Checkbox
+            checked={!!defaultValue}
+            disabled={!!disabled}
+            onChange={(e) => onChange(e.target.checked)}
+          />
+        }
         label={label}
       />
     );
@@ -43,7 +49,6 @@ function FieldRendererComponent({ field, defaultValue, onRef }: FieldRendererPro
   if (type === 'select') {
     return (
       <SmartSelect
-        ref={(el) => onRef(el)}
         label={label}
         required={required}
         multiple={multiple}
@@ -61,7 +66,6 @@ function FieldRendererComponent({ field, defaultValue, onRef }: FieldRendererPro
   if (type === 'file') {
     return (
       <SmartFileInput
-        ref={(el) => onRef(el)}
         label={label}
         allowedTypes={allowedFormats}
         maxSizeMb={maxFileSizeMB}
@@ -77,7 +81,6 @@ function FieldRendererComponent({ field, defaultValue, onRef }: FieldRendererPro
   if (type === 'date') {
     return (
       <SmartDateInput
-        ref={(el) => onRef(el)}
         label={label}
         required={required}
         defaultValue={defaultValue}
@@ -91,7 +94,6 @@ function FieldRendererComponent({ field, defaultValue, onRef }: FieldRendererPro
 
   return (
     <SmartInput
-      ref={(el) => onRef(el)}
       type={type === 'textarea' ? 'text' : type}
       isTextArea={type === 'textarea'}
       label={label}

--- a/src/common/components/ModalForm/index.tsx
+++ b/src/common/components/ModalForm/index.tsx
@@ -1,23 +1,19 @@
-'use client';
+'use client'
 
-import React, { useRef, useCallback, useMemo, useState, useEffect } from 'react';
-import {
-  Typography,
-  Divider,
-  Stack,
-} from '@mui/material';
+import React, { useMemo, useEffect } from 'react'
+import { Typography, Divider, Stack } from '@mui/material'
+import Grid from '@mui/material/GridLegacy'
+import { useForm, Controller } from 'react-hook-form'
 
-import Grid from '@mui/material/GridLegacy';
+import Modal from '../Modal'
+import SmartButton from '../SmartButton'
+import FieldRenderer from './FieldRenderer'
 
-import Modal from '../Modal';
-import SmartButton from '../SmartButton';
-import FieldRenderer from './FieldRenderer';
+import { ModalFormProps, FieldSchema } from './types'
 
-import { SmartInputRef } from '../SmartInput';
-import { SmartSelectRef } from '../SmartSelect';
-import { SmartFileInputRef } from '../SmartFileInput';
-
-import { ModalFormProps, FieldSchema } from './types';
+function getValueFromPath(obj: Record<string, any>, path: string): any {
+  return path.split('.').reduce((acc, part) => acc?.[part], obj)
+}
 
 export default function ModalForm({
   isOpen,
@@ -32,121 +28,87 @@ export default function ModalForm({
   schema,
   data = {}
 }: ModalFormProps) {
-  const refs = useRef<Record<string, SmartInputRef | SmartSelectRef | SmartFileInputRef>>({});
-  const [formValues, setFormValues] = useState<Record<string, any>>(data);
+  const {
+    control,
+    handleSubmit,
+    reset,
+    watch,
+    getValues,
+    formState: { isValid }
+  } = useForm({ defaultValues: data, mode: 'onChange' })
 
   useEffect(() => {
     if (isOpen) {
-      setFormValues(data);
+      reset(data)
     }
-  }, [isOpen, data]);
+  }, [isOpen, data, reset])
 
-  const handleFieldRef = useCallback(
-    (key: string, ref: any) => {
-      if (ref) refs.current[key] = ref;
-    },
-    []
-  );
+  const formValues = watch()
 
-  function getValueFromPath(obj: Record<string, any>, path: string): any {
-    return path.split('.').reduce((acc, part) => acc?.[part], obj);
-  }
+  const visibleFields = useMemo(
+    () =>
+      schema.filter((field) => {
+        if (typeof field.hidden === 'function') {
+          return !field.hidden(formValues)
+        }
+        return !field.hidden
+      }),
+    [schema, formValues]
+  )
 
-  function setValueToPath(obj: Record<string, any>, path: string, value: any) {
-    const parts = path.split('.');
-    let current = obj;
+  const gridFields = useMemo(
+    () =>
+      visibleFields.map((field: FieldSchema) => {
+        const { breakpoint = { xs: 12 } } = field
 
-    parts.forEach((part, index) => {
-      if (index === parts.length - 1) {
-        current[part] = value;
-      } else {
-        current[part] = current[part] ?? {};
-        current = current[part];
-      }
-    });
-  }
-
-  const handleChange = useCallback(
-    (key: string, value: any) => {
-      setFormValues((prev) => {
-        const updated = { ...prev };
-        setValueToPath(updated, key, value);
-
-        const fieldSchema = schema.find((f) => f.key === key);
-        if (fieldSchema?.onChange) {
-          try {
-            fieldSchema.onChange(updated, value);
-          } catch (e) {
-            console.warn(`Error en onChange de ${key}`, e);
-          }
+        const evaluatedField: FieldSchema = {
+          ...field,
+          disabled:
+            readOnly ||
+            (typeof field.disabled === 'function' ? field.disabled(formValues) : field.disabled)
         }
 
-        return updated;
-      });
-    },
-    [schema]
-  );
+        return (
+          <Grid item {...breakpoint} key={field.key}>
+            <Controller
+              name={field.key}
+              control={control}
+              defaultValue={getValueFromPath(data, field.key) ?? ''}
+              rules={{
+                required: field.required ? 'Campo obligatorio' : false,
+                minLength: field.minLength
+                  ? { value: field.minLength, message: `Mínimo ${field.minLength}` }
+                  : undefined,
+                maxLength: field.maxLength
+                  ? { value: field.maxLength, message: `Máximo ${field.maxLength}` }
+                  : undefined,
+                pattern: field.pattern,
+              }}
+              render={({ field: { onChange } }) => (
+                <FieldRenderer
+                  field={evaluatedField}
+                  defaultValue={getValueFromPath(data, field.key) ?? ''}
+                  onChange={(value) => {
+                    onChange(value)
+                    field.onChange?.(getValues(), value)
+                  }}
+                />
+              )}
+            />
+          </Grid>
+        )
+      }),
+    [visibleFields, formValues, control, data, readOnly, getValues]
+  )
 
-  const handleSubmit = useCallback(() => {
-    let isValid = true;
-    const values: Record<string, any> = {};
-
-    for (const key of Object.keys(refs.current)) {
-      const fieldRef = refs.current[key];
-      const valid = fieldRef?.validate?.();
-      if (!valid) isValid = false;
-
-      const value = fieldRef?.getValue?.();
-      setValueToPath(values, key, value);
-    }
-
-    if (!isValid) return;
-
-    onSubmit(values);
-  }, [onSubmit]);
-
-  const visibleFields = useMemo(() => (
-    schema.filter((field) => {
-      if (typeof field.hidden === 'function') {
-        return !field.hidden(formValues);
-      }
-      return !field.hidden;
-    })
-  ), [schema, formValues]);
-
-  const gridFields = useMemo(() => (
-    visibleFields.map((field: FieldSchema) => {
-      const { breakpoint = { xs: 12 } } = field;
-
-      const evaluatedField: FieldSchema = {
-        ...field,
-        disabled: readOnly || (typeof field.disabled === 'function'
-          ? field.disabled(formValues)
-          : field.disabled),
-        onChange: (value: any) => handleChange(field.key, value),
-      };
-
-      return (
-        <Grid item {...breakpoint} key={field.key}>
-          <FieldRenderer
-            field={evaluatedField}
-            defaultValue={getValueFromPath(formValues, field.key) ?? ''}
-            onRef={(ref) => handleFieldRef(field.key, ref)}
-          />
-        </Grid>
-      );
-
-    })
-  ), [visibleFields, formValues, handleFieldRef, readOnly, handleChange]);
-
-  if (!isOpen) return null;
+  if (!isOpen) return null
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} size="md" noIconClose>
-      <Typography variant="h5" color="text.primary" fontWeight={700} mb={2}>
+    <Modal isOpen={isOpen} onClose={() => { reset(); onClose() }} size='md' noIconClose>
+      <Typography variant='h5' color='text.primary' fontWeight={700} mb={2}>
         {title}
         {description && (
-          <Typography variant="body2" color="text.secondary" mb={2}>
+          <Typography variant='body2' color='text.secondary' mb={2}>
             {description}
           </Typography>
         )}
@@ -156,26 +118,36 @@ export default function ModalForm({
         {gridFields}
       </Grid>
 
+      <Typography variant='caption' color='text.secondary' mt={1}>
+        Los campos marcados con * son obligatorios
+      </Typography>
+
       <Divider sx={{ my: 2 }} />
 
-      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} justifyContent="flex-end">
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} justifyContent='flex-end'>
         <SmartButton
           label={cancelText}
-          variant="outlined"
-          onClick={onClose}
+          variant='outlined'
+          onClick={() => {
+            reset()
+            onClose()
+          }}
           sx={{ flex: 1, padding: readOnly ? '' : '0 38px' }}
           loading={loading}
         />
         {!readOnly && (
           <SmartButton
             label={confirmText}
-            variant="contained"
-            onClick={handleSubmit}
+            variant='contained'
+            onClick={handleSubmit((vals) => {
+              onSubmit(vals)
+            })}
             fullWidth
             loading={loading}
+            disabled={!isValid}
           />
         )}
       </Stack>
     </Modal>
-  );
+  )
 }

--- a/src/common/components/SmartInput/index.tsx
+++ b/src/common/components/SmartInput/index.tsx
@@ -157,7 +157,7 @@ const SmartInputComponent = memo(forwardRef<SmartInputRef, SmartInputProps>((pro
         helperText={touched && error ? error : ''}
         InputLabelProps={{
           sx: { color: 'text.secondary' },
-          shrink: true,
+          shrink: touched || value !== '' || isTextArea,
         }}
         InputProps={{
           startAdornment: leftIcon ? (

--- a/src/common/components/ui/Navbar/UserMenu.tsx
+++ b/src/common/components/ui/Navbar/UserMenu.tsx
@@ -217,15 +217,16 @@ export default function UserMenu() {
         }}>
         {renderMenuContent()}
       </Drawer>
-      <ModalForm
-        title="Perfil"
-        readOnly
-        data={currentUser || {}}
-        description="Este es tu perfil del usuario"
-        isOpen={modalProfile.isOpen}
-        onClose={() => setModalProfile({ isOpen: false, isEdit: false, title: "", description: "" })}
-        onSubmit={() => { }}
-        schema={[
+      {modalProfile.isOpen && (
+        <ModalForm
+          title="Perfil"
+          readOnly
+          data={currentUser || {}}
+          description="Este es tu perfil del usuario"
+          isOpen={modalProfile.isOpen}
+          onClose={() => setModalProfile({ isOpen: false, isEdit: false, title: "", description: "" })}
+          onSubmit={() => { }}
+          schema={[
           {
             key: "username",
             label: "Nombre de usuario",
@@ -275,9 +276,9 @@ export default function UserMenu() {
             label: "Genero",
             breakpoint: { xs: 6 }
           },
-        ]
-        }>
-      </ModalForm>
+        ]}
+        />
+      )}
     </Box >
   );
 }

--- a/src/modules/businessUnit/ui/BusinessUnitView.tsx
+++ b/src/modules/businessUnit/ui/BusinessUnitView.tsx
@@ -81,16 +81,17 @@ export function BusinessUnitView() {
         }}
       />
 
-      <ModalForm
-        loading={loading}
-        data={selected}
-        isOpen={showModalForm.isOpen}
-        title={showModalForm.title}
-        onClose={handleCloseModal}
-        onSubmit={(values) => {
-          createBusinessUnit(values, showModalForm.isEdit, selected, handleCloseModal);
-        }}
-        schema={[
+      {showModalForm.isOpen && (
+        <ModalForm
+          loading={loading}
+          data={selected}
+          isOpen={showModalForm.isOpen}
+          title={showModalForm.title}
+          onClose={handleCloseModal}
+          onSubmit={(values) => {
+            createBusinessUnit(values, showModalForm.isEdit, selected, handleCloseModal);
+          }}
+          schema={[
           {
             key: "businessUnitName",
             label: "Nombre",
@@ -112,7 +113,8 @@ export function BusinessUnitView() {
             required: showModalForm.isEdit ? false : true,
           },
         ]}
-      />
+        />
+      )}
     </Fragment>
   );
 }

--- a/src/modules/role/ui/ProfileView.tsx
+++ b/src/modules/role/ui/ProfileView.tsx
@@ -109,34 +109,39 @@ export function ProfileView() {
         onConfirm={() => deleteProfile(selected, handleCloseModal)}
       />
 
-      <ModalForm
-        loading={loading}
-        data={selected}
-        isOpen={showFormModal.isOpen}
-        onClose={handleCloseModal}
-        onSubmit={(values) =>
-          submitProfile(values, showFormModal.isEdit, selected, handleCloseModal)
-        }
-        title={showFormModal.title}
-        description={showFormModal.description}
-        schema={[
+      {showFormModal.isOpen && (
+        <ModalForm
+          loading={loading}
+          data={selected}
+          isOpen={showFormModal.isOpen}
+          onClose={handleCloseModal}
+          onSubmit={(values) =>
+            submitProfile(values, showFormModal.isEdit, selected, handleCloseModal)
+          }
+          title={showFormModal.title}
+          description={showFormModal.description}
+          schema={[
           {
             key: "roleName",
             label: "Nombre rol",
             required: true,
           }
         ]}
-      />
+        />
+      )}
 
-      <ModalForm
-        loading={loading}
-        data={selected}
-        isOpen={showRequestModal.isOpen}
-        onClose={handleCloseModal}
-        onSubmit={(values) => submitProfileXRequest(values, selected, handleCloseModal)}
-        title={showRequestModal.title}
-        description={showRequestModal.description}
-        schema={[
+      {showRequestModal.isOpen && (
+        <ModalForm
+          loading={loading}
+          data={selected}
+          isOpen={showRequestModal.isOpen}
+          onClose={handleCloseModal}
+          onSubmit={(values) =>
+            submitProfileXRequest(values, selected, handleCloseModal)
+          }
+          title={showRequestModal.title}
+          description={showRequestModal.description}
+          schema={[
           {
             key: 'permissions',
             label: 'Permisos',
@@ -147,7 +152,8 @@ export function ProfileView() {
             options: catalogs.requests,
           }
         ]}
-      />
+        />
+      )}
     </Fragment>
   );
 }

--- a/src/modules/user/ui/UserView.tsx
+++ b/src/modules/user/ui/UserView.tsx
@@ -115,17 +115,18 @@ export function UserView() {
         }}
       />
 
-      <ModalForm
-        loading={loading}
-        data={selected}
-        isOpen={showFormModal.isOpen}
-        onClose={handleCloseModal}
-        onSubmit={(values) =>
-          submitUser(values, showFormModal.isEdit, selected, handleCloseModal)
-        }
-        title={showFormModal.title}
-        description={showFormModal.description}
-        schema={[
+      {showFormModal.isOpen && (
+        <ModalForm
+          loading={loading}
+          data={selected}
+          isOpen={showFormModal.isOpen}
+          onClose={handleCloseModal}
+          onSubmit={(values) =>
+            submitUser(values, showFormModal.isEdit, selected, handleCloseModal)
+          }
+          title={showFormModal.title}
+          description={showFormModal.description}
+          schema={[
           {
             key: "username",
             label: "Usuario",
@@ -207,7 +208,8 @@ export function UserView() {
             options: catalogs.profiles,
           },
         ]}
-      />
+        />
+      )}
     </Fragment>
   );
 }


### PR DESCRIPTION
## Summary
- rewrite ModalForm to use `react-hook-form`
- simplify FieldRenderer signature
- unmount ModalForm when closed across the app
- add `react-hook-form` dependency
- disable save button when form is invalid
- show caption explaining required fields
- fix SmartInput label that remained shrunk

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a4d4ff234833096dc0c0c1a364788