### PR TITLE
Add nested array filter support

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -159,6 +159,12 @@ Sistema de tabla avanzado que incluye búsqueda, ordenamiento, filtros dinámico
 - Acciones por fila mediante menús.
 - Renderizado especial según el tipo de columna (`status`, `money`, `image`, etc.).
 
+Los filtros aceptan rutas usando notación de puntos para acceder a propiedades
+anidadas, por ejemplo `role.roleId`. Para filtrar arreglos de objetos se puede
+utilizar el comodín `*`, como en `businessUnits.*.businessUnitId`, de modo que
+la fila coincidirá si alguno de los elementos del arreglo contiene el valor
+seleccionado.
+
 ### Ejemplo básico
 ```tsx
 import SmartTable from '@/common/components/SmartTable/SmartTable'

--- a/src/common/components/SmartTable/SmartTableBody.tsx
+++ b/src/common/components/SmartTable/SmartTableBody.tsx
@@ -62,7 +62,12 @@ const SmartTableBody = ({
   }
 
   function getValueFromPath(obj: Record<string, any>, path: string): any {
-    return path.split('.').reduce((acc, key) => acc?.[key], obj);
+    return path.split('.').reduce((acc: any, key) => {
+      if (acc === undefined || acc === null) return undefined
+      if (key === '*') return acc
+      if (Array.isArray(acc)) return acc.map(item => item?.[key])
+      return acc[key]
+    }, obj)
   }
 
   const renderDefaultCell = useCallback((column: Column, value: any, row: Row) => {

--- a/src/common/components/SmartTable/useSmartTable.tsx
+++ b/src/common/components/SmartTable/useSmartTable.tsx
@@ -61,7 +61,12 @@ export function useSmartTable({
   }
 
   function getValueFromPath(obj: Record<string, any>, path: string): any {
-    return path.split('.').reduce((acc, key) => acc?.[key], obj)
+    return path.split('.').reduce((acc: any, key) => {
+      if (acc === undefined || acc === null) return undefined
+      if (key === '*') return acc
+      if (Array.isArray(acc)) return acc.map(item => item?.[key])
+      return acc[key]
+    }, obj)
   }
 
   const handleFilterChange = (label: string, value: string) => {
@@ -102,6 +107,9 @@ export function useSmartTable({
       if (value) {
         result = result.filter(row => {
           const target = getValueFromPath(row, key)
+          if (Array.isArray(target)) {
+            return target.flat(Infinity).includes(value)
+          }
           return target === value
         })
       }


### PR DESCRIPTION
## Summary
- support nested arrays in SmartTable's getValueFromPath helper
- check array values when applying filters
- document path/wildcard usage for filters

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b0701f4f48330b65e8987d76c10fa