### PR TITLE
Add chat page and sound notifications

### DIFF
--- a/src/common/components/ToastProvider/index.tsx
+++ b/src/common/components/ToastProvider/index.tsx
@@ -34,6 +34,23 @@ export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
   const timerRef = useRef<NodeJS.Timeout | null>(null)
   const transitionRef = useRef<NodeJS.Timeout | null>(null)
 
+  const playSound = () => {
+    try {
+      const AudioContext =
+        (window as any).AudioContext || (window as any).webkitAudioContext
+      if (!AudioContext) return
+      const ctx = new AudioContext()
+      const oscillator = ctx.createOscillator()
+      oscillator.type = 'sine'
+      oscillator.frequency.value = 520
+      oscillator.connect(ctx.destination)
+      oscillator.start()
+      oscillator.stop(ctx.currentTime + 0.2)
+    } catch {
+      // ignore errors in browsers without AudioContext
+    }
+  }
+
   const clearTimers = () => {
     if (timerRef.current) clearTimeout(timerRef.current)
     if (transitionRef.current) clearTimeout(transitionRef.current)
@@ -50,6 +67,7 @@ export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
     })
     setVariant('loading')
     setOpen(true)
+    playSound()
 
     transitionRef.current = setTimeout(() => {
       setVariant(options?.variant || 'info')

--- a/src/config/routes.tsx
+++ b/src/config/routes.tsx
@@ -4,6 +4,7 @@ import {
   AdminPanelSettings,
   DashboardRounded,
   Inventory,
+  ChatBubbleOutline,
 } from "@mui/icons-material";
 
 export const modulesList: IMenuItem[] = [
@@ -12,6 +13,13 @@ export const modulesList: IMenuItem[] = [
     icon: <DashboardRounded color="primary" />,
     link: "/home",
     description: "Resumen general del sistema y estadísticas",
+    permission: "dashboard",
+  },
+  {
+    label: "Chat",
+    icon: <ChatBubbleOutline color="primary" />,
+    link: "/chat",
+    description: "Comunicación entre usuarios",
     permission: "dashboard",
   },
   {

--- a/src/modules/chat/index.tsx
+++ b/src/modules/chat/index.tsx
@@ -1,0 +1,1 @@
+export { ChatView } from './ui/ChatView';

--- a/src/modules/chat/ui/ChatView.tsx
+++ b/src/modules/chat/ui/ChatView.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  Box,
+  Paper,
+  TextField,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+} from "@mui/material";
+import SendIcon from "@mui/icons-material/Send";
+import ChatBubbleOutlineIcon from "@mui/icons-material/ChatBubbleOutline";
+
+import { Header } from "@/common/components";
+
+export function ChatView() {
+  const [messages, setMessages] = useState<string[]>([]);
+  const [input, setInput] = useState("");
+
+  const handleSend = () => {
+    if (!input.trim()) return;
+    setMessages((prev) => [...prev, input.trim()]);
+    setInput("");
+  };
+
+  return (
+    <Box>
+      <Header
+        title="Chat de usuarios"
+        description="Comun\u00edcate con otros usuarios en tiempo real"
+        icon={<ChatBubbleOutlineIcon fontSize="large" color="primary" />}
+      />
+
+      <Paper sx={{ p: 2 }}>
+        <List sx={{ maxHeight: 300, overflowY: "auto" }}>
+          {messages.map((msg, index) => (
+            <ListItem key={index} disableGutters>
+              <ListItemText primary={msg} />
+            </ListItem>
+          ))}
+        </List>
+        <Box sx={{ display: "flex", mt: 2 }}>
+          <TextField
+            label="Escribe un mensaje"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            fullWidth
+            size="small"
+          />
+          <IconButton color="primary" onClick={handleSend} sx={{ ml: 1 }}>
+            <SendIcon />
+          </IconButton>
+        </Box>
+      </Paper>
+    </Box>
+  );
+}

--- a/src/pages/chat/index.tsx
+++ b/src/pages/chat/index.tsx
@@ -1,0 +1,10 @@
+import RootLayout from '@/common/components/ui/Layout';
+import { ChatView } from '@/modules/chat';
+
+export default function ChatPage() {
+  return (
+    <RootLayout>
+      <ChatView />
+    </RootLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ChatView` module with simple interface
- create `/chat` route and menu item
- play beep sound when showing toast notifications

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686211ec9f108330a10092eeea3b10a8